### PR TITLE
Fix Modern theme static assets and pager visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,6 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+# Deployment artifacts
+deploy.zip

--- a/Sockethead.Razor/Grid/SimpleGrid.cs
+++ b/Sockethead.Razor/Grid/SimpleGrid.cs
@@ -395,8 +395,8 @@ namespace Sockethead.Razor.Grid
             IQueryable<T> query = BuildQuery() ?? new List<T>().AsQueryable();
 
             int totalRecords = query.Count();
-            PagerOptions.Enabled = PagerOptions.Enabled &&
-                (PagerOptions.RowsPerPage < totalRecords || !PagerOptions.HideIfTooFewRows);
+            bool hideNavigation = PagerOptions.HideIfTooFewRows &&
+                totalRecords <= (State.RowsPerPage ?? PagerOptions.RowsPerPage);
 
             var vm = new SimpleGridViewModel
             {
@@ -421,7 +421,8 @@ namespace Sockethead.Razor.Grid
                         totalRecords: totalRecords,
                         displayTotal: PagerOptions.DisplayTotal,
                         rowsPerPage: State.RowsPerPage ?? PagerOptions.RowsPerPage,
-                        rowsPerPageOptions: PagerOptions.RowsPerPageOptions)
+                        rowsPerPageOptions: PagerOptions.RowsPerPageOptions,
+                        hideNavigation: hideNavigation)
                     : null,
 
                 // build search view model

--- a/Sockethead.Razor/Grid/State.cs
+++ b/Sockethead.Razor/Grid/State.cs
@@ -96,7 +96,8 @@ namespace Sockethead.Razor.Grid
                 [Fields.SearchNdxName] = null,
             };
 
-        public PagerModel BuildPagerModel(int totalRecords, bool displayTotal, int rowsPerPage, int[] rowsPerPageOptions)
+        public PagerModel BuildPagerModel(int totalRecords, bool displayTotal, int rowsPerPage, int[] rowsPerPageOptions,
+            bool hideNavigation = false)
         {
             int totalPages = (int)System.Math.Ceiling(totalRecords / (float)rowsPerPage);
             if (totalPages < 1)
@@ -110,6 +111,7 @@ namespace Sockethead.Razor.Grid
                 LastUrl = PageNum < totalPages ? BuildPageUrl(totalPages) : null,
                 CurrentPage = PageNum,
                 TotalPages = totalPages,
+                HideNavigation = hideNavigation,
             };
 
             if (displayTotal)

--- a/Sockethead.Razor/Pager/PagerModel.cs
+++ b/Sockethead.Razor/Pager/PagerModel.cs
@@ -15,5 +15,7 @@ namespace Sockethead.Razor.Pager
         public int? TotalItems { get; set; }
 
         public Dictionary<int, string> RowsPerPageLinks { get; set; }
+
+        public bool HideNavigation { get; set; }
     }
 }

--- a/Sockethead.Razor/Sockethead.Razor.csproj
+++ b/Sockethead.Razor/Sockethead.Razor.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Authors>Randall Eike</Authors>
     <Company>Eike Consulting, LLC</Company>
     <Description>Razor Utilities for ASP.NET Core.

--- a/Sockethead.Razor/Sockethead.Razor.csproj
+++ b/Sockethead.Razor/Sockethead.Razor.csproj
@@ -20,6 +20,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <StaticWebAssetsEnabled>true</StaticWebAssetsEnabled>
+    <StaticWebAssetsFingerprintContent>false</StaticWebAssetsFingerprintContent>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sockethead.Razor/Views/Shared/Modern/_SHPager.cshtml
+++ b/Sockethead.Razor/Views/Shared/Modern/_SHPager.cshtml
@@ -5,7 +5,10 @@
         {
             <span class="sh-pager-total">@Model.TotalItems.Value.ToString("N0") records</span>
         }
-        <span class="sh-pager-pages">Page @Model.CurrentPage of @Model.TotalPages</span>
+        @if (!Model.HideNavigation)
+        {
+            <span class="sh-pager-pages">Page @Model.CurrentPage of @Model.TotalPages</span>
+        }
     </div>
     <div class="sh-pager-controls">
         @if (Model.RowsPerPageLinks != null)
@@ -18,12 +21,15 @@
                 }
             </div>
         }
+        @if (!Model.HideNavigation)
+        {
         <div class="sh-pager-buttons">
             @{ PagerBtn(Model.FirstUrl, "&#171;", "First page"); }
             @{ PagerBtn(Model.PrevUrl, "&#8249;", "Previous page"); }
             @{ PagerBtn(Model.NextUrl, "&#8250;", "Next page"); }
             @{ PagerBtn(Model.LastUrl, "&#187;", "Last page"); }
         </div>
+        }
     </div>
 </nav>
 

--- a/Sockethead.Razor/Views/Shared/_SHPager.cshtml
+++ b/Sockethead.Razor/Views/Shared/_SHPager.cshtml
@@ -23,6 +23,8 @@
         </div>
     </div>
     }
+    @if (!Model.HideNavigation)
+    {
     <ul class="pagination justify-content-center">
         <li class="page-item @IsDisabled(Model.FirstUrl)"><a class="page-link" href="@Model.FirstUrl">First</a></li>
         <li class="page-item @IsDisabled(Model.PrevUrl)"><a class="page-link" href="@Model.PrevUrl">Prev</a></li>
@@ -30,4 +32,5 @@
         <li class="page-item @IsDisabled(Model.NextUrl)"><a class="page-link" href="@Model.NextUrl">Next</a></li>
         <li class="page-item @IsDisabled(Model.LastUrl)"><a class="page-link" href="@Model.LastUrl">Last</a></li>
     </ul>
+    }
 </nav>

--- a/Sockethead.Web/Properties/launchSettings.json
+++ b/Sockethead.Web/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },
     "Docker": {

--- a/Sockethead.Web/Startup.cs
+++ b/Sockethead.Web/Startup.cs
@@ -68,7 +68,10 @@ namespace Sockethead.Web
             }
 
             app.UseHttpsRedirection();
-            app.UseStaticFiles();
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider = env.WebRootFileProvider
+            });
 
             app.UseRouting();
 
@@ -77,6 +80,7 @@ namespace Sockethead.Web
 
             app.UseEndpoints(endpoints =>
             {
+                endpoints.MapStaticAssets();
                 endpoints.MapRazorPages();
 
                 endpoints.MapControllerRoute(

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+APP_NAME="Sockethead"
+RESOURCE_GROUP="appsvc_linux_centralus"
+PROJECT="Sockethead.Web/Sockethead.Web.csproj"
+PUBLISH_DIR="./publish"
+ZIP_FILE="deploy.zip"
+
+echo "==> Building and publishing..."
+dotnet publish "$PROJECT" -c Release -o "$PUBLISH_DIR"
+
+echo "==> Creating deployment package..."
+rm -f "$ZIP_FILE"
+cd "$PUBLISH_DIR"
+zip -r "../$ZIP_FILE" .
+cd ..
+
+echo "==> Getting deployment credentials..."
+CREDS=$(az webapp deployment list-publishing-credentials \
+    --name "$APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --query "{user:publishingUserName, pass:publishingPassword}" \
+    -o json)
+USER=$(echo "$CREDS" | python3 -c "import json,sys; print(json.load(sys.stdin)['user'])")
+PASS=$(echo "$CREDS" | python3 -c "import json,sys; print(json.load(sys.stdin)['pass'])")
+
+echo "==> Deploying to Azure..."
+STATUS=$(curl -s -w "%{http_code}" -o /dev/null \
+    -X POST --data-binary "@$ZIP_FILE" \
+    -H "Content-Type: application/zip" \
+    "https://$USER:$PASS@${APP_NAME,,}.scm.azurewebsites.net/api/zipdeploy?isAsync=true")
+
+if [ "$STATUS" = "202" ]; then
+    echo "==> Deployment accepted. Waiting for completion..."
+    for i in $(seq 1 30); do
+        sleep 5
+        RESULT=$(curl -s "https://$USER:$PASS@${APP_NAME,,}.scm.azurewebsites.net/api/deployments/latest")
+        COMPLETE=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('complete', False))")
+        if [ "$COMPLETE" = "True" ]; then
+            DEP_STATUS=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('status', -1))")
+            if [ "$DEP_STATUS" = "4" ]; then
+                echo "==> Deployment succeeded!"
+            else
+                echo "==> Deployment finished with status: $DEP_STATUS"
+            fi
+            break
+        fi
+        echo "    Still deploying... (${i})"
+    done
+else
+    echo "==> Deployment failed with HTTP status: $STATUS"
+    exit 1
+fi
+
+echo "==> Cleaning up..."
+rm -rf "$PUBLISH_DIR" "$ZIP_FILE"
+
+echo "==> Done! Site: https://${APP_NAME,,}.azurewebsites.net"

--- a/publish-nuget.sh
+++ b/publish-nuget.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+PROJECT="Sockethead.Razor/Sockethead.Razor.csproj"
+SOURCE="nuget.org"
+
+# Get current version from csproj
+VERSION=$(grep -oP '<Version>\K[^<]+' "$PROJECT")
+echo "==> Current version: $VERSION"
+
+# Get API key from NuGet config
+API_KEY=$(python3 -c "
+import xml.etree.ElementTree as ET
+tree = ET.parse('$HOME/.nuget/NuGet/NuGet.Config')
+for elem in tree.iter('add'):
+    if elem.get('key') == 'ClearTextPassword':
+        print(elem.get('value'))
+        break
+")
+
+if [ -z "$API_KEY" ]; then
+    echo "Error: No API key found in NuGet config."
+    echo "Run: dotnet nuget update source nuget.org --username ignored --password YOUR_KEY --store-password-in-clear-text"
+    exit 1
+fi
+
+echo "==> Building Release..."
+dotnet build "$PROJECT" -c Release
+
+NUPKG="Sockethead.Razor/bin/Release/Sockethead.Razor.${VERSION}.nupkg"
+if [ ! -f "$NUPKG" ]; then
+    echo "Error: Package not found at $NUPKG"
+    exit 1
+fi
+
+echo "==> Publishing Sockethead.Razor v${VERSION} to nuget.org..."
+read -p "    Continue? (y/N) " confirm
+if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+    echo "Aborted."
+    exit 0
+fi
+
+dotnet nuget push "$NUPKG" --source "$SOURCE" --api-key "$API_KEY"
+
+echo "==> Done! Package will appear at:"
+echo "    https://www.nuget.org/packages/Sockethead.Razor/${VERSION}"


### PR DESCRIPTION
## Summary
- **Fix RCL static web assets not serving on .NET 10** — use `env.WebRootFileProvider` in `UseStaticFiles`, add `MapStaticAssets()` to endpoint routing, and disable static web asset fingerprinting for backward-compatible `_content/` paths
- **Fix pager hiding total count and rows-per-page selector** — when all rows fit on one page, only hide navigation buttons instead of disabling the entire pager
- **Add deployment scripts** — `deploy.sh` for Azure App Service, `publish-nuget.sh` for NuGet publishing
- **Fix `launchSettings.json`** — `dotnetRunMessages` type from string to boolean for .NET 10 compatibility
- **Bump Sockethead.Razor to v1.3.0** (already published to nuget.org)

## Test plan
- [x] All 38 tests pass
- [x] Static CSS asset serves correctly at `/_content/Sockethead.Razor/css/sockethead-grid.css`
- [x] NuGet package v1.3.0 published successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)